### PR TITLE
update URL patterns for source and target views for clarity

### DIFF
--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -64,8 +64,8 @@ htmx_patterns = [
         views.check_target_bot,
         name="check_target_bot",
     ),
-    path("source/<int:pk>/", views.get_source, name="get_source"),
-    path("target/<int:pk>/", views.get_target, name="get_target"),
+    path("get-source/<int:pk>/", views.get_source, name="get_source"),
+    path("get-target/<int:pk>/", views.get_target, name="get_target"),
     path(
         "unlink-target/<int:source_id>/<int:target_id>/",
         views.unlink_target,


### PR DESCRIPTION
This pull request includes changes to the `tracker/urls.py` file to update the URL patterns for specific views. The most important change is the renaming of the URL paths for the `get_source` and `get_target` views to improve consistency and clarity.

URL path updates:

* [`tracker/urls.py`](diffhunk://#diff-65d4792afacbd28402325bd9e0c66f101802bd51a495f9340de7c73b15054af0L67-R68): Changed the URL path for the `get_source` view from `"source/<int:pk>/"` to `"get-source/<int:pk>/"` to make the path more descriptive.
* [`tracker/urls.py`](diffhunk://#diff-65d4792afacbd28402325bd9e0c66f101802bd51a495f9340de7c73b15054af0L67-R68): Changed the URL path for the `get_target` view from `"target/<int:pk>/"` to `"get-target/<int:pk>/"` to make the path more descriptive.