### PR TITLE
fix

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -35,8 +35,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install docker-compose -y
 
       - name: Start services with Docker Compose
-        run: docker-compose up -d -f docker-compose-dev.yml --build
+        run: docker-compose up -d --build
 
       - name: Run Tests
         run: |
-          docker-compose -f docker-compose-dev.yml exec -T django pytest
+          docker-compose exec -T django pytest

--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -37,8 +37,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install docker-compose -y
 
       - name: Start services with Docker Compose
-        run: docker-compose up -d -f docker-compose-dev.yml --build
+        run: docker-compose up -d --build
 
       - name: Run migrations
         run: |
-          docker-compose -f docker-compose-dev.yml exec -T django python manage.py migrate || { echo 'Migrations failed'; exit 1; }
+          docker-compose exec -T django python manage.py migrate || { echo 'Migrations failed'; exit 1; }


### PR DESCRIPTION
This pull request includes changes to the Docker Compose commands in the deployment workflows to improve the order of arguments.

Deployment workflow improvements:

* [`.github/workflows/deployment-tests.yml`](diffhunk://#diff-02a744835786bceabefef4efd2c7d86eb8bacc190ffb7fd4c54c735f7ef57d90L38-R38): Modified the Docker Compose command to place the `-d` argument before the `-f` argument for better readability and consistency.
* [`.github/workflows/docker-deployment.yml`](diffhunk://#diff-dba7aa7f88c187af597b13e6a9a71d4171ae4cb4433b9cf58c59e8f97e455501L40-R40): Updated the Docker Compose command to position the `-d` argument before the `-f` argument for improved clarity and uniformity.